### PR TITLE
Return a promise when not updating token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-redhat",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Client side JavaScript library to interact with Red Hat JWT",
   "main": "dist/jwt.js",
   "types": "src/index.d.ts",

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -478,6 +478,11 @@ function updateToken(force?: boolean): ISimplePromise {
                 .error(updateTokenFailure);
         } else {
             log('[jwt.js] skipping updateToken call as this tab is a slave, see master tab');
+            // TODO -- consider broadcasting a message to the master to update.
+            // Also consider the implications of default returning a setSuccess here
+            const promise = createPromise();
+            promise.setSuccess();
+            return promise.promise;
         }
     } else {
         log('[jwt.js] running updateToken (without cross-tab communcation)');


### PR DESCRIPTION
Need to always return a promise even when not updating the promise (when current tab is the slave)