### PR TITLE
Gracefully handling slave token update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-redhat",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Client side JavaScript library to interact with Red Hat JWT",
   "main": "dist/jwt.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
If the master token update fails, we should gracefully update the slave instead of just allowing the stale token to remain in place. 