### PR TITLE
commenting out master/slave scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-redhat",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Client side JavaScript library to interact with Red Hat JWT",
   "main": "dist/jwt.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
The master/slave logic for handling token updates is just not reliable enough yet when there are token update failures.  The logic works fine when the token updates properly.  When there is a token update failure, expected or unexpected, the tokens aren't properly synced to the slave tabs.  Disabling the master/slave logic for now until we can shore this up.