### PR TITLE
Moving to traditional promises for update token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-redhat",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Client side JavaScript library to interact with Red Hat JWT",
   "main": "dist/jwt.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
Let's handle the update token with traditional promises, which we should anyways as it isn't advised to return a nested promise which attempts to handle it's own errors.