### PR TITLE
Using local storage as the main storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-redhat",
-  "version": "0.0.22",
+  "version": "0.0.24",
   "description": "Client side JavaScript library to interact with Red Hat JWT",
   "main": "dist/jwt.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-redhat",
-  "version": "0.0.23",
+  "version": "0.0.22",
   "description": "Client side JavaScript library to interact with Red Hat JWT",
   "main": "dist/jwt.js",
   "types": "src/index.d.ts",

--- a/src/cacheUtils.ts
+++ b/src/cacheUtils.ts
@@ -8,7 +8,8 @@ import * as localForage      from 'localforage';
 export const CACHE_STORAGE_NAME = 'jwt-redhat-lf';
 
 localForage.config({
-    name: CACHE_STORAGE_NAME
+    name: CACHE_STORAGE_NAME,
+    driver: [localForage.LOCALSTORAGE]
 });
 
 export interface ICacheOptions {

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -230,7 +230,17 @@ function init(keycloakOptions: Partial<IKeycloakOptions>, keycloakInitOptions?: 
     // TODO -- then this, also look in keycloak.js to see if any sort of exp field is set, I think so?
     return Promise.all([CacheUtils.get<IStringCache>(TOKEN_NAME), CacheUtils.get<IStringCache>(REFRESH_TOKEN_NAME)]).then((results) => {
 
-        if (results && results[0] && results[0].value !== 'undefined') { KEYCLOAK_INIT_OPTIONS.token = results[0].value; }
+        let token = null;
+        if (results && results[0] && results[0].value !== 'undefined') {
+             token = results[0].value;
+        } else {
+            token = lib.getCookieValue(TOKEN_NAME);
+        }
+
+        if (token) {
+            KEYCLOAK_INIT_OPTIONS.token = token;
+        }
+
         if (results && results[1] && results[1].value !== 'undefined') { KEYCLOAK_INIT_OPTIONS.refreshToken = results[1].value; }
 
         state.keycloak = Keycloak(keycloakOptions ? Object.assign({}, KEYCLOAK_OPTIONS, keycloakOptions) : KEYCLOAK_OPTIONS);


### PR DESCRIPTION
Given that the keycloak.js login-status-iframe.html does not handle old token session information well, we need to always ensure we load the token from the same offline storage engine that any other referring browser sessions uses.  Since the CSP exclusively uses localStorage, then we need to follow suite. 