### PR TITLE
Maintaining parity within multi-versioned environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-redhat",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Client side JavaScript library to interact with Red Hat JWT",
   "main": "dist/jwt.js",
   "types": "src/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ declare namespace Jwt {
     export function getLogoutUrl(): string;
     export function getAccountUrl(): string;
     export function getToken(): IToken;
-    export function getStoredTokenValue(): Promise<string>;
+    export function getStoredTokenValue(): string;
     export function getEncodedToken(): string;
     export function getUserInfo(): IJwtUser;
     export function updateToken(force?: boolean): ISimplePromise;
@@ -35,7 +35,7 @@ declare namespace Jwt {
     export function onTokenExpired(func: Function): void;
     export function onInitialUpdateToken(func: Function): void;
     export function isMaster(): boolean;
-    export function init(keycloakOptions: Partial<IKeycloakOptions>, keycloakInitOptions?: Partial<IKeycloakInitOptions>): Promise<void | Keycloak.KeycloakPromise<boolean, Keycloak.KeycloakError>>;
+    export function init(keycloakOptions: Partial<IKeycloakOptions>, keycloakInitOptions?: Partial<IKeycloakInitOptions>): Keycloak.KeycloakPromise<boolean, Keycloak.KeycloakError>;
     export function enableDebugLogging();
     export function disableDebugLogging();
     export const _state: IState;


### PR DESCRIPTION
Redirecting from pages with a different means of storing the tokens (even within localStorage) can result in problems, thus we need to maintain exact parity with any other versions of sessionjs which may store tokens under different names.