### PR TITLE
Fixing bad sub-sub-domain for internal auth in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-redhat",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Client side JavaScript library to interact with Red Hat JWT",
   "main": "dist/jwt.js",
   "types": "src/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,7 @@ import { ISimplePromise }   from './simulatedPromise';
 import { Keycloak }         from '../@types/keycloak';
 import { INumberCache }     from './cacheUtils';
 
-import { 
+import {
     ILoginOptions,
     IToken,
     IInternalToken,

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -940,7 +940,8 @@ function ssoUrl(isInternal?: boolean) {
         case 'ci.foo.redhat.com':
         default:
             log('[jwt.js] ENV: ci');
-            return `https://${subDomain}.dev2.redhat.com/auth`;
+            const subSubDomain = isInternal === true ? 'dev' : 'dev2';
+            return `https://${subDomain}.${subSubDomain}.redhat.com/auth`;
     }
 }
 


### PR DESCRIPTION
The internal auth endpoint is just `dev` not `dev2` and fails when using internal auth.